### PR TITLE
파워업 아이템을 먹으면 미사일 개수가 추가되도록 기능 추가

### DIFF
--- a/main.html
+++ b/main.html
@@ -1,18 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>개발고미의 슈팅게임</title>
+  </head>
 
-</head>
-
-
-<body>
-
-</body>
-<script src="scripts/logic.js"></script>
-
+  <body>
+    ㄴㅁ이ㅏ럼ㄴㅇ라ㅣㄴ이ㅏ
+  </body>
+  <script src="scripts/logic.js"></script>
 </html>

--- a/main.html
+++ b/main.html
@@ -6,9 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>개발고미의 슈팅게임</title>
   </head>
-
-  <body>
-    ㄴㅁ이ㅏ럼ㄴㅇ라ㅣㄴ이ㅏ
-  </body>
+  <body></body>
   <script src="scripts/logic.js"></script>
 </html>


### PR DESCRIPTION
# 수정 사항
적군의 우주선을 격추하여 생성된 파워업 아이템을 먹을 때마다 미사일 개수가 추가되도록 기능을 추가했습니다.

구체적으로 다음 수정사항들이 있습니다.
- 적군의 우주선을 격추하면 파워업 아이템이 생성되도록 수정
- 파워업 아이템 별로 습득한 순간부터 10초 동안 총알 개수 1개 증가
- 총알이 캔버스의 위쪽 끝에 도달하면 삭제되도록 수정
- 파워업 아이템이 캔버스의 아래쪽 끝에 도달하면 삭제되도록 수정